### PR TITLE
(완료)(NYU-16)[Sprint1]IMG-SERVER restriction settings and swagger sett…

### DIFF
--- a/NYU-IMG/pom.xml
+++ b/NYU-IMG/pom.xml
@@ -19,6 +19,23 @@
         <spring-native.version>0.11.3</spring-native.version>
     </properties>
     <dependencies>
+
+
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -67,7 +84,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>2.6.4</version>
         </dependency>
-
 
     </dependencies>
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/NyuImgApplication.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/NyuImgApplication.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 public class NyuImgApplication {
 
     public static void main(String[] args) {
+
         SpringApplication.run(NyuImgApplication.class, args);
     }
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/config/SwaggerConfig.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.nyanyumserver.nyuimg.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    @Bean
+    public Docket swaggerApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.nyanyumserver.nyuimg"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/controller/ImageController.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/controller/ImageController.java
@@ -1,18 +1,22 @@
-package com.nyanyumserver.nyuimg.Controller;
+package com.nyanyumserver.nyuimg.controller;
 
-import com.nyanyumserver.nyuimg.Global.status.StatusCode;
-import com.nyanyumserver.nyuimg.Global.status.StatusResponse;
-import lombok.RequiredArgsConstructor;
+import com.nyanyumserver.nyuimg.global.status.StatusCode;
+import com.nyanyumserver.nyuimg.global.status.StatusResponse;
+import io.swagger.annotations.*;
+import lombok.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import com.nyanyumserver.nyuimg.Service.ImageService;
+import com.nyanyumserver.nyuimg.service.ImageService;
+
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/auth")
 public class ImageController {
     private final ImageService imageService;
+
 
     /**
      * 이미지 변경하기
@@ -24,7 +28,15 @@ public class ImageController {
      * @param uid
      * @param multipartFile
      */
-    @PostMapping("/auth/updateProfileImage")
+    @ApiResponses({
+            @ApiResponse(code=200, message="이미지 업데이트 완료"),
+            @ApiResponse(code=415, message="파일 형식 미지원 (지원가능 확장자  : '.bmp', '.jpeg', '.jpg', '.png', '.tif', '.tiff', '.svg')"),
+            @ApiResponse(code=416, message="파일 용량 초과 (용량 제한 : 3MB)"),
+            @ApiResponse(code=417, message="사용자 전송 파일 없음")
+    })
+    @ApiImplicitParam(name = "uid", value = "사용자 uid", required = true, dataType = "String")
+    @ApiOperation(value = "이미지 변경하기")
+    @PostMapping("/updateProfileImage")
     public ResponseEntity<StatusResponse> uploadImage(
             @RequestParam("uid") String uid,
             @RequestPart(value = "file") MultipartFile multipartFile) {
@@ -39,7 +51,13 @@ public class ImageController {
      * @param uid
      * @return ImageURI
      */
-    @GetMapping("/auth/downloadProfileImage")
+    @ApiResponses({
+            @ApiResponse(code=200, message="이미지 다운로드 완료"),
+            @ApiResponse(code=204, message="S3 버킷내에 해당 uid 사용자 이미지 없음")
+    })
+    @ApiImplicitParam(name = "uid", value = "사용자 uid", required = true, dataType = "String")
+    @ApiOperation(value = "이미지 가져오기")
+    @GetMapping("/downloadProfileImage")
     public ResponseEntity<StatusResponse> downloadImage(
             @RequestParam("uid") String uid) {
             String resourcePath = imageService.downloadImage(uid);
@@ -52,7 +70,13 @@ public class ImageController {
      *
      * @param uid
      */
-    @DeleteMapping("/auth/deleteProfileImage")
+    @ApiResponses({
+            @ApiResponse(code=200, message="이미지 삭제 완료"),
+            @ApiResponse(code=204, message="S3 버킷내에 해당 uid 사용자 이미지 없음")
+    })
+    @ApiImplicitParam(name = "uid", value = "사용자 uid", required = true, dataType = "String")
+    @ApiOperation(value = "이미지 삭제하기")
+    @DeleteMapping("/deleteProfileImage")
     public ResponseEntity<StatusResponse> deleteImage(
             @RequestParam("uid") String uid) {
             imageService.deleteImage(uid);

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/ErrorResponse.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/ErrorResponse.java
@@ -1,6 +1,6 @@
-package com.nyanyumserver.nyuimg.Global.error;
+package com.nyanyumserver.nyuimg.global.error;
 
-import com.nyanyumserver.nyuimg.Global.error.exception.ErrorCode;
+import com.nyanyumserver.nyuimg.global.error.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/GlobalExceptionHandler.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/GlobalExceptionHandler.java
@@ -1,21 +1,27 @@
-package com.nyanyumserver.nyuimg.Global.error;
+package com.nyanyumserver.nyuimg.global.error;
 
-import com.nyanyumserver.nyuimg.Global.error.exception.BusinessException;
-import com.nyanyumserver.nyuimg.Global.error.exception.ErrorCode;
+import com.nyanyumserver.nyuimg.global.error.exception.BusinessException;
+import com.nyanyumserver.nyuimg.global.error.exception.EntityNotFoundException;
+import com.nyanyumserver.nyuimg.global.error.exception.ErrorCode;
+
+import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 
-import com.nyanyumserver.nyuimg.Global.status.StatusCode;
-import com.nyanyumserver.nyuimg.Global.status.StatusResponse;
+import com.nyanyumserver.nyuimg.global.status.StatusCode;
+import com.nyanyumserver.nyuimg.global.status.StatusResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 @ControllerAdvice
 @Slf4j
@@ -83,15 +89,29 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
     }
 
-    /**
-     *
-     * 사용자 전송 파일 없음
-     */
     @ExceptionHandler(IllegalArgumentException.class)
     protected ResponseEntity<ErrorResponse> handleException(IllegalArgumentException e) {
         log.error("IllegalArgumentException", e);
-        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_MEDIA_TYPE);
+        return new ResponseEntity<>(response, HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(
+            MaxUploadSizeExceededException e) {
+        log.info("handleMaxUploadSizeExceededException", e);
+
+        ErrorResponse response = ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEED);
+        return new ResponseEntity<>(response, HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    protected ResponseEntity<ErrorResponse> handleMultipartException(
+            MultipartException e) {
+        log.info("handleMultipartException", e);
+
+        ErrorResponse response = ErrorResponse.of(ErrorCode.EXPECTATION_FAILED);
+        return new ResponseEntity<>(response, HttpStatus.EXPECTATION_FAILED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/BusinessException.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/BusinessException.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Global.error.exception;
+package com.nyanyumserver.nyuimg.global.error.exception;
 
 
 public class BusinessException extends RuntimeException {

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/EntityNotFoundException.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/EntityNotFoundException.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Global.error.exception;
+package com.nyanyumserver.nyuimg.global.error.exception;
 
 public class EntityNotFoundException extends BusinessException {
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/ErrorCode.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Global.error.exception;
+package com.nyanyumserver.nyuimg.global.error.exception;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -12,6 +12,10 @@ public enum ErrorCode {
     INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
     HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
     BAD_REQUEST(400, "C007", " Bad Request"),
+    UNSUPPORTED_MEDIA_TYPE(415, "C008", "UNSUPPORTED_MEDIA_TYPE"),
+    FILE_SIZE_EXCEED(416, "C009", "REQUESTED_RANGE_NOT_SATISFIABLE"),
+    EXPECTATION_FAILED(417, "C010", "EXPECTATION_FAILED")
+
 
 
     ;

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/InvalidValueException.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/error/exception/InvalidValueException.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Global.error.exception;
+package com.nyanyumserver.nyuimg.global.error.exception;
 
 public class InvalidValueException extends BusinessException {
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/status/StatusCode.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/status/StatusCode.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Global.status;
+package com.nyanyumserver.nyuimg.global.status;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/status/StatusResponse.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/global/status/StatusResponse.java
@@ -1,18 +1,26 @@
-package com.nyanyumserver.nyuimg.Global.status;
+package com.nyanyumserver.nyuimg.global.status;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.net.URI;
 
+@ApiModel(value = "모델 태그 정보")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StatusResponse {
-
-    private String message;
-    private int status;
+    @ApiModelProperty(value = "이미지 url",name = "entity", example = "https://nyu-img-bucket.s3.ap-northeast-2.amazonaws.com/{uid}/{filename}", required = true)
     private String entity;
+    @ApiModelProperty(value = "상태 메시지",name = "message", example = "OK", required = true)
+    private String message;
+    @ApiModelProperty(value = "상태 코드",name = "status", example = "200", required = true)
+    private int status;
+    @ApiModelProperty(value = "리다이렉트 url",name = "redirect", example = "null", required = true)
     private URI redirect;
 
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/service/ImageService.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/service/ImageService.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Service;
+package com.nyanyumserver.nyuimg.service;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/service/component/Component.java
+++ b/NYU-IMG/src/main/java/com/nyanyumserver/nyuimg/service/component/Component.java
@@ -1,4 +1,4 @@
-package com.nyanyumserver.nyuimg.Service.component;
+package com.nyanyumserver.nyuimg.service.component;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/NYU-IMG/src/main/resources/application.properties
+++ b/NYU-IMG/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-
 logging.level.com.amazonaws.util.EC2MetadataUtils: error
 
 
@@ -9,5 +8,4 @@ logging:
         util:
             EC2MetadataUtils: error
 
-
-server.port = 80
+server.port = 81


### PR DESCRIPTION
## **💡 Issue**

[NYU-16]

## **⚡ Content**

- Swagger 추가했습니다.
- 파일 용량 제한, 확장자 제한 설정했습니다.

## **🌟 Point**

- 서버 81 포트 열어뒀습니다.
- [Confluence](https://nyanyumuniv.atlassian.net/wiki/spaces/NYU/pages/524289?atlOrigin=eyJpIjoiYjFiYTk0NjE2OTA1NGE4MWJjYTljN2UwMWQ0MTI2MDEiLCJwIjoiaiJ9) 에서 `application.yml` 파일 확인해주세요!
- Open API Method : `DELETE`, `POST` 
- 파일 지원 가능 확장자 : '.bmp', '.jpeg', '.jpg', '.png', '.tif', '.tiff', '.svg'

##  **❓ Question**
- 용량 어느정도가 적당할까요...?

[NYU-16]: https://nyanyumuniv.atlassian.net/browse/NYU-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ