### PR TITLE
Hotfix:메뉴명 중복 데이터 필터링

### DIFF
--- a/NYU-Main/src/main/resources/mapper/MenuMapper.xml
+++ b/NYU-Main/src/main/resources/mapper/MenuMapper.xml
@@ -19,7 +19,7 @@
     <select id="getValid" resultMap="MenuInfo">
         SELECT storeId
         FROM menu
-        WHERE menuAlias = #{menuAlias};
+        WHERE menuAlias = #{menuAlias} AND storeId = #{storeId};
     </select>
 
     <insert id="setMenu">

--- a/NYU_Manage/Procfile
+++ b/NYU_Manage/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn NYU_Manage.wsgi --log-file -

--- a/NYU_Manage/requirements.txt
+++ b/NYU_Manage/requirements.txt
@@ -1,8 +1,13 @@
 asgiref==3.5.2
+dj-database-url==1.0.0
 Django==4.1
 django-admin-rangefilter==0.8.7
 django-jazzmin==2.5.0
+gunicorn==20.1.0
+install==1.3.5
 mysql-client==0.0.1
 mysqlclient==2.1.1
 PyMySQL==1.0.2
+python-decouple==3.6
 sqlparse==0.4.2
+whitenoise==6.2.0


### PR DESCRIPTION
## **⚡ Content**

- 기존
   - 전체 메뉴에서 동일 명칭 메뉴 추가 불가
- 수정
   - 가게명 다를 시, 동일 명칭 메뉴 추가 가능 